### PR TITLE
More general voltageSweep methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ Higher level commands defined in the driver:
 ## Installation
 Download or clone the repository. Install the package by running 
 ```console
-$ pip install /path/to/folder
+$ pip git+https://github.com/OE-FET/keithley2600
 ```
-where "/path/to/folder" is the path to the folder containing setup.py. 
 
 ##  Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Higher level commands defined in the driver:
 >>> k.applyCurrent(k.smub, 0.1) # sources 0.1A from k.smub
 >>> k.rampToVoltage(k.smua, 10, delay=0.1, stepSize=1) # ramps k.smua to 10V in 1V steps
 
->>> k.voltageSweepSingleSMU(smu=k.smua, sweep_list=list(range(0, 61)),
+>>> k.voltageSweepSingleSMU(smu=k.smua, smu_sweeplist=list(range(0, 61)),
                             tInt=0.1, delay=-1, pulsed=False)  # records single SMU IV curve
 >>> k.voltageSweepDualSMU(smu1=k.smua, smu2=k.smub, smu1_sweeplist=list(range(0, 61)),
                           smu2_sweeplist=list(range(0, 61)), tInt=0.1, delay=-1,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Keithley driver with access to base functions and higher level functions such as
 There are currently no checks for allowed arguments in the base commands. See the [Keithley 2600 reference manual](https://www.tek.com/keithley-source-measure-units/smu-2600b-series-sourcemeter-manual-8) for all available commands and arguments. Almost all remotely accessible commands can be used with this driver. Not supported are:
 
 * tspnet.excecute() # conflicts with Python's execute command
-* lan.trigger[N].connected # conflicts with connected attribute of Keithley2600Base
+* lan.trigger[N].connected # conflicts with the connected attribute of Keithley2600Base
 * All Keithley IV sweep commands. We implement our own in the Keithley2600 class.
 
 *Usage:*

--- a/README.md
+++ b/README.md
@@ -26,15 +26,18 @@ Higher level commands defined in the driver:
 
 ```python
 >>> data = k.readBuffer('smua.nvbuffer1')
->>> k.clearBuffers() # clears ALL smu buffers
->>> k.setIntegrationTime(k.smua, 0.001) # sets integration time to 0.001 sec
->>> k.applyVoltage(k.smua, -60) # applies -60V to smuA
->>> k.applyCurrent(k.smub, 0.1) # sources 0.1A from smuB
->>> k.rampToVoltage(k.smua, 10, delay=0.1, stepSize=1)
->>> Vsweep, Isweep, Vfix, Ifix = k.voltageSweep(smu_sweep=k.smua, smu_fix=k.smub, VStart=0, VStop=-60,
-               VStep=1, VFix=0, tInt=0.1, delay=-1, pulsed=True)# records an IV curve
->>> data1 = k.outputMeasurement(...) # records an output curve of a transistor
->>> data2 = k.transferMeasurement(...) # records a transfer curve of a transistor
+>>> k.clearBuffer(k.sma) # clears buffer of k.smua
+>>> k.setIntegrationTime(k.smua, 0.001) # in sec
+
+>>> k.applyVoltage(k.smua, -60) # applies -60V to k.smua
+>>> k.applyCurrent(k.smub, 0.1) # sources 0.1A from k.smub
+>>> k.rampToVoltage(k.smua, 10, delay=0.1, stepSize=1) # ramps k.smua to 10V in 1V steps
+
+>>> k.voltageSweepSingleSMU(smu=k.smua, sweep_list=list(range(0, 61)),
+                            tInt=0.1, delay=-1, pulsed=False)  # records single SMU IV curve
+>>> k.voltageSweepDualSMU(smu1=k.smua, smu2=k.smub, smu1_sweeplist=list(range(0, 61)),
+                          smu2_sweeplist=list(range(0, 61)), tInt=0.1, delay=-1,
+                          pulsed=False)  # records dual SMU IV curve
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Keithley driver with access to base functions and higher level functions such as
 There are currently no checks for allowed arguments in the base commands. See the [Keithley 2600 reference manual](https://www.tek.com/keithley-source-measure-units/smu-2600b-series-sourcemeter-manual-8) for all available commands and arguments. Almost all remotely accessible commands can be used with this driver. Not supported are:
 
 * tspnet.excecute() # conflicts with Python's execute command
+* lan.trigger[N].connected # conflicts with connected attribute of Keithley2600Base
 * All Keithley IV sweep commands. We implement our own in the Keithley2600 class.
 
 *Usage:*
@@ -38,7 +39,7 @@ Higher level commands defined in the driver:
 
 
 ## Installation
-Download or clone the repository. Install the package by running 
+Download or clone the repository. Install the package by running
 ```console
 $ pip git+https://github.com/OE-FET/keithley2600
 ```

--- a/keithley2600/keithley_doc.py
+++ b/keithley2600/keithley_doc.py
@@ -471,6 +471,8 @@ CLASSES = [
             'measurement',
             'measuring',
             'node',
+            'nvbuffer1',
+            'nvbuffer1',
             'operation',
             'os',
             'over_temperature',

--- a/keithley2600/keithley_doc.py
+++ b/keithley2600/keithley_doc.py
@@ -472,7 +472,7 @@ CLASSES = [
             'measuring',
             'node',
             'nvbuffer1',
-            'nvbuffer1',
+            'nvbuffer2',
             'operation',
             'os',
             'over_temperature',

--- a/keithley2600/keithley_doc.py
+++ b/keithley2600/keithley_doc.py
@@ -314,7 +314,7 @@ PROPERTIES = [
             'speed',
             'subnetmask',
             'timedwait',
-            'connected',
+            # 'connected', # TODO: conflicts with connected attribute of Keithley2600Base
             'ipaddress',
             'mode',
             'overrun',
@@ -666,7 +666,7 @@ ALL = [
  'lan.trigger.disconnect',
  'lan.trigger.wait',
  'lan.trigger[N].EVENT_ID',
- 'lan.trigger[N].connected',
+ # 'lan.trigger[N].connected',  # TODO: conflicts with connected attribute of Keithley2600Base
  'lan.trigger[N].ipaddress',
  'lan.trigger[N].mode',
  'lan.trigger[N].overrun',

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -17,8 +17,7 @@ import numpy as np
 import time
 
 # local import
-from keithley2600.keithley_doc import (CONSTANTS, FUNCTIONS, PROPERTIES,
-                                       PROPERTY_LISTS)
+from keithley2600.keithley_doc import CONSTANTS, FUNCTIONS, PROPERTIES, CLASSES, PROPERTY_LISTS
 from keithley2600.sweep_data_class import TransistorSweepData
 
 logger = logging.getLogger(__name__)
@@ -55,18 +54,10 @@ class MagicPropertyList(object):
         return self
 
     def _write(self, value):
-        try:
-            self._parent._write(value)
-        except AttributeError:
-            logger.debug(value)
-            pass
+        self._parent._write(value)
 
     def _query(self, value):
-        try:
-            return self._parent._query(value)
-        except AttributeError:
-            logger.debug('print(%s)' % value)
-            return None
+        return self._parent._query(value)
 
     def _convert_input(self, value):
         try:
@@ -126,17 +117,15 @@ class MagicClass(object):
 
     USAGE:
         inst = MagicClass('keithley')
-        inst.reset() - dynamically creates a new attribute 'reset' and sets it
-                       to a MagicFunction instance. Then calls it.
-        inst.beeper  - dynamically creats new attribute 'beeper' and sets it to
+        inst.reset() - Dynamically creates a new attribute 'reset' as an instance
+                       of MagicFunction, then calls it.
+        inst.beeper  - Dynamically creats new attribute 'beeper' and sets it to
                        a new MagicClass instance.
-        newclass.beeper.enable - fakes the property 'enable' of 'beeper'
+        newclass.beeper.enable - Fakes the property 'enable' of 'beeper'
                                  with _write as setter and _query as getter.
 
     """
 
-    visa_library = ''
-    visa_address = ''
     _name = ''
     _parent = None
 
@@ -149,10 +138,10 @@ class MagicClass(object):
     def __getattr__(self, attr):
         try:
             try:
-                # check if attribute already exists
+                # check if attribute already exists. return attr if yes.
                 return object.__getattr__(self, attr)
             except AttributeError:
-                # check if key already exists
+                # check if key already exists. return value if yes.
                 return self.__dict__[attr]
         except KeyError:
             # handle if not
@@ -173,9 +162,12 @@ class MagicClass(object):
             else:
                 handler = self._query(new_name)
 
-        else:
+        elif name in CLASSES:
             handler = MagicClass(new_name, parent=self)
             self.__dict__[new_name] = handler
+
+        else:
+            raise AttributeError("'%s' object has no attribute '%s'" % (type(self), name))
 
         return handler
 
@@ -190,18 +182,10 @@ class MagicClass(object):
             self.__dict__[attr] = value
 
     def _write(self, value):
-        try:
-            self._parent._write(value)
-        except AttributeError:
-            logger.debug(value)
-            pass
+        self._parent._write(value)
 
     def _query(self, value):
-        try:
-            return self._parent._query(value)
-        except AttributeError:
-            logger.debug('print(%s)' % value)
-            return None
+        return self._parent._query(value)
 
     def _convert_input(self, value):
         try:
@@ -259,25 +243,27 @@ class Keithley2600Base(MagicClass):
 # Connect to keithley
 # =============================================================================
 
-    def __new__(cls, visa_address, visa_library):
-        cls.visa_address = visa_address
-        cls.visa_library = visa_library
-        return super(Keithley2600Base, cls).__new__(cls)
-
     def __init__(self, visa_address, visa_library):
-        MagicClass.__init__(self, '', parent=self)
-        # open Keithley Visa resource
-        self.rm = visa.ResourceManager(self.visa_library)
+        MagicClass.__init__(self, name='', parent=self)
+
+        self.visa_address = visa_address
+        self.visa_library = visa_library
+
         self.connect()
 
     def connect(self):
         """
         Connects to Keithley and opens pyvisa API.
         """
+
+        # open visa resource manager with selected library / backend
+        self.rm = visa.ResourceManager(self.visa_library)
+
+        # try to connect to keithley
         try:
             self.connection = self.rm.open_resource(self.visa_address)
             self.connection.read_termination = '\n'
-            Keithley2600Base.connected = True
+            Keithley2600Base.connected = True  # must assign to class variable since keithley TSP has connected property
 
             self.beeper.beep(0.3, 1046.5)
             self.beeper.beep(0.3, 1318.5)
@@ -287,21 +273,25 @@ class Keithley2600Base(MagicClass):
             logger.warning('Could not connect to Keithley.')
             self.connection = None
             Keithley2600Base.connected = False
+            self.rm.close()
 
     def disconnect(self):
         """ Disconnect from Keithley """
-        if self.connected:
+        if self.connection:
             try:
                 self.beeper.beep(0.3, 1568)
                 self.beeper.beep(0.3, 1318.5)
                 self.beeper.beep(0.3, 1046.5)
 
                 self.connection.close()
+                self.connection = None
                 Keithley2600Base.connected = False
                 del self.connection
             except AttributeError:
                 Keithley2600Base.connected = False
                 pass
+
+        self.rm.close()
 
 # =============================================================================
 # Define I/O
@@ -312,17 +302,25 @@ class Keithley2600Base(MagicClass):
         Writes text to Keithley. Input must be a string.
         """
         logger.debug(value)
-        self.connection.write(value)
+
+        if self.connection:
+            self.connection.write(value)
+        else:
+            raise OSError('No keithley connected.')
 
     def _query(self, value):
         """
         Queries and expects response from Keithley. Input must be a string.
         """
-        with self._lock:
-            r = self.connection.query('print(%s)' % value)
-
         logger.debug('print(%s)' % value)
-        return self.parse_response(r)
+
+        if self.connection:
+            with self._lock:
+                r = self.connection.query('print(%s)' % value)
+
+            return self.parse_response(r)
+        else:
+            raise OSError('No keithley connected.')
 
     def parse_response(self, string):
         try:
@@ -391,11 +389,6 @@ class Keithley2600(Keithley2600Base):
     """
 
     SMU_LIST = ['smua', 'smub']
-
-    def __new__(cls, visa_address, visa_library='@py'):
-        cls.visa_address = visa_address
-        cls.visa_library = visa_library
-        return super(Keithley2600, cls).__new__(cls, visa_address, visa_library)
 
     def __init__(self, visa_address, visa_library='@py'):
         Keithley2600Base.__init__(self, visa_address, visa_library)

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -218,6 +218,7 @@ class Keithley2600Base(MagicClass):
         commands and arguments. Almost all remotely accessible commands can be
         used with this driver. NOT SUPPORTED ARE:
              * tspnet.excecute() # conflicts with Python's excecute command
+             * lan.trigger[N].connected # conflicts with connected attribute of Keithley2600Base
              * All Keithley IV sweep commands. We implement our own in the
                Keithley2600 class.
 
@@ -263,7 +264,7 @@ class Keithley2600Base(MagicClass):
         try:
             self.connection = self.rm.open_resource(self.visa_address)
             self.connection.read_termination = '\n'
-            Keithley2600Base.connected = True  # must assign to class variable since keithley TSP has connected property
+            self.connected = True
 
             self.beeper.beep(0.3, 1046.5)
             self.beeper.beep(0.3, 1318.5)
@@ -272,7 +273,7 @@ class Keithley2600Base(MagicClass):
             # TODO: catch specific error once implemented in pyvisa-py
             logger.warning('Could not connect to Keithley.')
             self.connection = None
-            Keithley2600Base.connected = False
+            self.connected = False
             self.rm.close()
 
     def disconnect(self):
@@ -285,10 +286,10 @@ class Keithley2600Base(MagicClass):
 
                 self.connection.close()
                 self.connection = None
-                Keithley2600Base.connected = False
+                self.connected = False
                 del self.connection
             except AttributeError:
-                Keithley2600Base.connected = False
+                self.connected = False
                 pass
 
         self.rm.close()

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -390,7 +390,7 @@ class Keithley2600(Keithley2600Base):
         >>> k.applyCurrent(k.smub, 0.1) # sources 0.1A from smuB
         >>> k.rampToVoltage(k.smua, 10, delay=0.1, stepSize=1)
 
-        >>> k.voltageSweepSingleSMU(smu=k.smua, sweep_list=list(range(0, 61)),
+        >>> k.voltageSweepSingleSMU(smu=k.smua, smu_sweeplist=list(range(0, 61)),
                                     tInt=0.1, delay=-1, pulsed=False)  # records single SMU IV curve
         >>> k.voltageSweepDualSMU(smu1=k.smua, smu2=k.smub, smu1_sweeplist=list(range(0, 61)),
                                   smu2_sweeplist=list(range(0, 61)), tInt=0.1, delay=-1,

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -223,7 +223,7 @@ class Keithley2600Base(MagicClass):
         commands and arguments. Almost all remotely accessible commands can be
         used with this driver. NOT SUPPORTED ARE:
              * tspnet.excecute() # conflicts with Python's excecute command
-             * lan.trigger[N].connected # conflicts with connected attribute of Keithley2600Base
+             * lan.trigger[N].connected # conflicts with the connected attribute of Keithley2600Base
              * All Keithley IV sweep commands. We implement our own in the
                Keithley2600 class.
 

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -436,21 +436,12 @@ class Keithley2600(Keithley2600Base):
 
     def clearBuffer(self, smu):
         """ Clears buffer of given smu."""
-<<<<<<< HEAD
 
         self._check_smu(smu)
 
         smu.nvbuffer1.clear()
         smu.nvbuffer2.clear()
 
-=======
-
-        self._check_smu(smu)
-
-        smu.nvbuffer1.clear()
-        smu.nvbuffer2.clear()
-
->>>>>>> accc766c6a70058cae775e69d918809977c4640a
         smu.nvbuffer1.clearcache()
         smu.nvbuffer2.clearcache()
 
@@ -553,7 +544,6 @@ class Keithley2600(Keithley2600Base):
         smu.measure.autorangei = smu.AUTORANGE_ON
 
         # smu.trigger.source.limiti = 0.1
-<<<<<<< HEAD
 
         smu.source.func = smu.OUTPUT_DCVOLTS
 
@@ -594,48 +584,6 @@ class Keithley2600(Keithley2600Base):
 
         smu.trigger.measure.iv(buffer_smu_1, buffer_smu_2)
 
-=======
-
-        smu.source.func = smu.OUTPUT_DCVOLTS
-
-        # 2-wire measurement (use SENSE_REMOTE for 4-wire)
-        # smu.sense = smu.SENSE_LOCAL
-
-        # clears SMU buffers
-        smu.nvbuffer1.clear()
-        smu.nvbuffer2.clear()
-
-        smu.nvbuffer1.clearcache()
-        smu.nvbuffer2.clearcache()
-
-        # diplay current values during measurement
-        self.display.smua.measure.func = self.display.MEASURE_DCAMPS
-        self.display.smub.measure.func = self.display.MEASURE_DCAMPS
-
-        # SETUP TRIGGER ARM AND COUNTS
-        # trigger count = number of data points in measurement
-        # arm count = number of times the measurement is repeated (set to 1)
-
-        npts = len(smu_sweeplist)
-        smu.trigger.count = npts
-
-        # SET THE MEASUREMENT TRIGGER ON BOTH SMU'S
-        # Set measurment to trigger once a change in the gate value on
-        # sweep smu is complete, i.e., a measurment will occur
-        # after the voltage is stepped.
-        # Both channels should be set to trigger on the sweep smu event
-        # so the measurements occur at the same time.
-
-        # enable smu
-        smu.trigger.measure.action = smu.ENABLE
-
-        # measure current on trigger, store in buffer of smu
-        buffer_smu_1 = '%s.nvbuffer1' % self._get_smu_string(smu)
-        buffer_smu_2 = '%s.nvbuffer2' % self._get_smu_string(smu)
-
-        smu.trigger.measure.iv(buffer_smu_1, buffer_smu_2)
-
->>>>>>> accc766c6a70058cae775e69d918809977c4640a
         # initiate measure trigger when source is complete
         smu.trigger.measure.stimulus = smu.trigger.SOURCE_COMPLETE_EVENT_ID
 
@@ -980,19 +928,11 @@ class Keithley2600(Keithley2600Base):
 
             if not self.abort_event.is_set():
                 sd.append(vFix=Vdrain, vSweep=vg_fwd, iDrain=id_fwd, iGate=ig_fwd)
-<<<<<<< HEAD
 
             # conduct backward sweep
             sweeplist_gate = np.flip(sweeplist_gate)
             sweeplist_drain = np.flip(sweeplist_drain)
 
-=======
-
-            # conduct backward sweep
-            sweeplist_gate = np.flip(sweeplist_gate)
-            sweeplist_drain = np.flip(sweeplist_drain)
-
->>>>>>> accc766c6a70058cae775e69d918809977c4640a
             vg_rvs, ig_rvs, vd_rvs, id_rvs = self.voltageSweepDualSMU(
                     smu_gate, smu_drain, sweeplist_gate, sweeplist_drain, tInt, delay, pulsed
                     )

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -210,6 +210,10 @@ class MagicClass(object):
         pass
 
 
+class KeithleyIOError(Exception):
+    pass
+
+
 class Keithley2600Base(MagicClass):
     """
 
@@ -278,7 +282,7 @@ class Keithley2600Base(MagicClass):
             self.beeper.beep(0.3, 1568)
         except:
             # TODO: catch specific error once implemented in pyvisa-py
-            logger.warning('Could not connect to Keithley.')
+            logger.warning('Could not connect to Keithley at %s.' % self.visa_address)
             self.connection = None
             self.connected = False
             self.rm.close()
@@ -314,7 +318,7 @@ class Keithley2600Base(MagicClass):
         if self.connection:
             self.connection.write(value)
         else:
-            raise OSError('No keithley connected.')
+            raise KeithleyIOError('No connection to keithley present. Try to call connect().')
 
     def _query(self, value):
         """
@@ -328,7 +332,7 @@ class Keithley2600Base(MagicClass):
 
             return self.parse_response(r)
         else:
-            raise OSError('No keithley connected.')
+            raise KeithleyIOError('No connection to keithley present. Try to call connect().')
 
     def parse_response(self, string):
         try:

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -89,10 +89,15 @@ class MagicFunction(object):
         self._parent = parent
 
     def __call__(self, *args, **kwargs):
-        # Pass on to calls to self._write, store result in variable.
-        # Querying results from function calls directly may result in
-        # a VisaIOError timeout if the function does not return anything.
+        """ Pass on calls to self._write, store result in variable.
+        Querying results from function calls directly may result in
+        a VisaIOError timeout if the function does not return anything."""
+
+        # convert incompatible aruments, return as list
+        args = tuple(self._parent._convert_input(a) for a in args)
+        # remove outside brackets and all quotation marks
         args_string = str(args).strip("(),").replace("'", "")
+        # pass on calls to self._write
         self._parent._write('result = %s(%s)' % (self._name, args_string))
         # query for result in second call
         return self._parent._query('result')
@@ -240,6 +245,8 @@ class Keithley2600Base(MagicClass):
     connected = False
     busy = False
 
+    TO_TSP_LIST = (list, np.ndarray, tuple, set)
+
 # =============================================================================
 # Connect to keithley
 # =============================================================================
@@ -339,9 +346,14 @@ class Keithley2600Base(MagicClass):
         return r
 
     def _convert_input(self, value):
+        """ Convert bools to lower case strings and lists / tuples to comma delimted strings
+        enclosed by curly brackets."""
         if isinstance(value, bool):
+            # convert bool True to string 'true'
             value = str(value).lower()
-
+        elif isinstance(value, self.TO_TSP_LIST):
+            # convert some iterables to a TSP type list '{1,2,3,4}'
+            value = '{%s}' % ', '.join(map(str, value))
         return value
 
 
@@ -371,16 +383,18 @@ class Keithley2600(Keithley2600Base):
         New mid-level commands:
 
         >>> data = k.readBuffer('smua.nvbuffer1')
-        >>> k.clearBuffers() # clears ALL smu buffers
+        >>> k.clearBuffer(k.sma) # clears buffer of smuA
         >>> k.setIntegrationTime(k.smua, 0.001) # in sec
 
         >>> k.applyVoltage(k.smua, -60) # applies -60V to smuA
         >>> k.applyCurrent(k.smub, 0.1) # sources 0.1A from smuB
         >>> k.rampToVoltage(k.smua, 10, delay=0.1, stepSize=1)
 
-        >>> k.voltageSweep(smu_sweep=k.smua, smu_fix=k.smub, VStart=0,
-                           VStop=-60, VStep=1, VFix=0, tInt=0.1, delay=-1,
-                           pulsed=True) # records IV curve
+        >>> k.voltageSweepSingleSMU(smu=k.smua, sweep_list=range(0,61),
+                                    tInt=0.1, delay=-1, pulsed=True) # records single SMU IV curve
+        >>> k.voltageSweepDualSMU(smu_1=k.smua, smu_2=k.smub, sweep_list_1=range(0,61),
+                                  sweep_list_2=[0]*10, tInt=0.1, delay=-1,
+                                  pulsed=True) # records dual SMU IV curve
 
         New high-level commands:
 
@@ -420,16 +434,16 @@ class Keithley2600(Keithley2600Base):
         self._write('%s.clearcache()' % bufferName)
         return list_out
 
-    def clearBuffers(self):
-        """ Clears all SMU buffers."""
-        for smu_string in self.SMU_LIST:
-            smu = getattr(self, smu_string)
+    def clearBuffer(self, smu):
+        """ Clears buffer of given smu."""
 
-            smu.nvbuffer1.clear()
-            smu.nvbuffer2.clear()
+        self._check_smu(smu)
 
-            smu.nvbuffer1.clearcache()
-            smu.nvbuffer2.clearcache()
+        smu.nvbuffer1.clear()
+        smu.nvbuffer2.clear()
+
+        smu.nvbuffer1.clearcache()
+        smu.nvbuffer2.clearcache()
 
     def setIntegrationTime(self, smu, tInt):
         """ Sets the integration time of SMU for measurements in sec. """
@@ -481,7 +495,7 @@ class Keithley2600(Keithley2600Base):
         self.display.smua.measure.func = self.display.MEASURE_DCVOLTS
         self.display.smub.measure.func = self.display.MEASURE_DCVOLTS
 
-        step = np.sign(targetVolt-Vcurr)*abs(stepSize)
+        step = np.sign(targetVolt - Vcurr) * abs(stepSize)
 
         for V in np.arange(Vcurr-step, targetVolt-step, step):
             smu.source.levelv = V
@@ -493,88 +507,57 @@ class Keithley2600(Keithley2600Base):
 
         self.beeper.beep(0.3, 2400)
 
-    def voltageSweep(self, smu_sweep, smu_fix, VStart, VStop, VStep, VFix,
-                     tInt, delay, pulsed):
+    def voltageSweepSingleSMU(self, smu1, smu1_sweeplist, tInt, delay, pulsed):
         """
-        Sweeps voltage at one SMU (smu_sweep) while keeping the second at
-        a constant voltage VFix. The option VFix = 'trailing' will sweep both
-        SMUs simulateously.
-
-        Measures and returns current and voltage during sweep.
+        Sweeps voltage at one SMU. Measures and returns current and voltage during sweep.
 
         INPUTS:
-            smu_sweep - SMU to be sweept
-            smu_fix - SMU to be kept at fixed voltage
-            VStart - start voltage for sweep (float)
-            Vstop - stop voltage for sweep (float)
-            VStep - sweep steps (float)
-            VFix - constant voltage for second SMU (Volts or 'trailing')
+            smu1 - 1st SMU to be sweept
+            smu1_sweeplist - array of voltages to sweep
             tInt - integration time per data point (float)
             delay - settling delay before measurement (float)
             pulsed - continous or pulsed sweep (bool)
         """
-        self._check_smu(smu_sweep)
-        self._check_smu(smu_fix)
 
+        # input checks
+        self._check_smu(smu1)
+
+        # set state to busy
         self.busy = True
-        # define list containing results. If we abort early, we have something
-        # to return
-        Vsweep, Isweep, Vfix, Ifix = [], [], [], []
+        # Define lists containing results. If we abort early, we have something to return.
+        v_smu1, i_smu1 = [], []
 
         if self.abort_event.is_set():
             self.busy = False
-            return Vsweep, Isweep, Vfix, Ifix
+            return v_smu1, i_smu1
 
-        # Setup smua/smub for sweep measurement. The voltage is swept from
-        # VStart to VStop in intervals of VStep with a measuremnt at each step.
-        numPoints = 1 + abs((VStop-VStart)/VStep)
-
-        # setup smu_sweep to sweep votage linearly
-        smu_sweep.trigger.source.linearv(VStart, VStop, numPoints)
-        smu_sweep.trigger.source.action = smu_sweep.ENABLE
-
-        if VFix == 'trailing':
-            # setup smu_fix to sweep votage linearly
-            smu_fix.trigger.source.linearv(VStart, VStop, numPoints)
-            smu_fix.trigger.source.action = smu_fix.ENABLE
-
-        else:
-            # setup smu_fix to remain at a constant voltage
-            smu_fix.trigger.source.linearv(VFix, VFix, numPoints)
-            smu_fix.trigger.source.action = smu_fix.ENABLE
+        # setup smu1 to sweep through list on trigger
+        smu1.trigger.source.listv(smu1_sweeplist)
+        smu1.trigger.source.action = smu1.ENABLE
 
         # CONFIGURE INTEGRATION TIME FOR EACH MEASUREMENT
         nplc = tInt * self.localnode.linefreq
-        smu_sweep.measure.nplc = nplc
-        smu_fix.measure.nplc = nplc
+        smu1.measure.nplc = nplc
 
         # CONFIGURE SETTLING TIME FOR GATE VOLTAGE, I-LIMIT, ETC...
-        smu_sweep.measure.delay = delay
-        smu_fix.measure.delay = delay
+        smu1.measure.delay = delay
+        smu1.measure.autorangei = smu1.AUTORANGE_ON
 
-        smu_sweep.measure.autorangei = smu_sweep.AUTORANGE_ON
-        smu_fix.measure.autorangei = smu_fix.AUTORANGE_ON
+        # smu1.trigger.source.limiti = 0.1
+        # smu2.trigger.source.limiti = 0.1
 
-        # smu_sweep.trigger.source.limiti = 0.1
-        # smu_fix.trigger.source.limiti = 0.1
-
-        smu_sweep.source.func = smu_sweep.OUTPUT_DCVOLTS
-        smu_fix.source.func = smu_fix.OUTPUT_DCVOLTS
+        smu1.source.func = smu1.OUTPUT_DCVOLTS
 
         # 2-wire measurement (use SENSE_REMOTE for 4-wire)
-        # smu_sweep.sense = smu_sweep.SENSE_LOCAL
-        # smu_fix.sense = smu_fix.SENSE_LOCAL
+        # smu1.sense = smu1.SENSE_LOCAL
+        # smu2.sense = smu2.SENSE_LOCAL
 
         # clears SMU buffers
-        smu_sweep.nvbuffer1.clear()
-        smu_sweep.nvbuffer2.clear()
-        smu_fix.nvbuffer1.clear()
-        smu_fix.nvbuffer2.clear()
+        smu1.nvbuffer1.clear()
+        smu1.nvbuffer2.clear()
 
-        smu_sweep.nvbuffer1.clearcache()
-        smu_sweep.nvbuffer2.clearcache()
-        smu_fix.nvbuffer1.clearcache()
-        smu_fix.nvbuffer2.clearcache()
+        smu1.nvbuffer1.clearcache()
+        smu1.nvbuffer2.clearcache()
 
         # diplay current values during measurement
         self.display.smua.measure.func = self.display.MEASURE_DCAMPS
@@ -584,8 +567,8 @@ class Keithley2600(Keithley2600Base):
         # trigger count = number of data points in measurement
         # arm count = number of times the measurement is repeated (set to 1)
 
-        smu_sweep.trigger.count = numPoints
-        smu_fix.trigger.count = numPoints
+        npts = len(smu1_sweeplist)
+        smu1.trigger.count = npts
 
         # SET THE MEASUREMENT TRIGGER ON BOTH SMU'S
         # Set measurment to trigger once a change in the gate value on
@@ -595,21 +578,16 @@ class Keithley2600(Keithley2600Base):
         # so the measurements occur at the same time.
 
         # enable smu
-        smu_sweep.trigger.measure.action = smu_sweep.ENABLE
-        smu_fix.trigger.measure.action = smu_fix.ENABLE
+        smu1.trigger.measure.action = smu1.ENABLE
+
         # measure current on trigger, store in buffer of smu
+        buffer_smu1_1 = '%s.nvbuffer1' % self._get_smu_string(smu1)
+        buffer_smu1_2 = '%s.nvbuffer2' % self._get_smu_string(smu1)
 
-        buffer_sweep_1 = '%s.nvbuffer1' % self._get_smu_string(smu_sweep)
-        buffer_sweep_2 = '%s.nvbuffer2' % self._get_smu_string(smu_sweep)
+        smu1.trigger.measure.iv(buffer_smu1_1, buffer_smu1_2)
 
-        buffer_fix_1 = '%s.nvbuffer1' % self._get_smu_string(smu_fix)
-        buffer_fix_2 = '%s.nvbuffer2' % self._get_smu_string(smu_fix)
-
-        smu_sweep.trigger.measure.iv(buffer_sweep_1, buffer_sweep_2)
-        smu_fix.trigger.measure.iv(buffer_fix_1, buffer_fix_2)
         # initiate measure trigger when source is complete
-        smu_sweep.trigger.measure.stimulus = smu_sweep.trigger.SOURCE_COMPLETE_EVENT_ID
-        smu_fix.trigger.measure.stimulus = smu_sweep.trigger.SOURCE_COMPLETE_EVENT_ID
+        smu1.trigger.measure.stimulus = smu1.trigger.SOURCE_COMPLETE_EVENT_ID
 
         # SET THE ENDPULSE ACTION TO HOLD
         # Options are SOURCE_HOLD AND SOURCE_IDLE, hold maintains same voltage
@@ -623,21 +601,19 @@ class Keithley2600(Keithley2600Base):
         else:
             raise TypeError("'pulsed' must be of type 'bool'.")
 
-        smu_sweep.trigger.endpulse.action = endPulseAction
-        smu_fix.trigger.endpulse.action = endPulseAction
+        smu1.trigger.endpulse.action = endPulseAction
 
         # SET THE ENDSWEEP ACTION TO HOLD IF NOT PULSED
         # Output voltage will be held after sweep is done!
 
-        smu_sweep.trigger.endsweep.action = endPulseAction
-        smu_fix.trigger.endsweep.action = endPulseAction
+        smu1.trigger.endsweep.action = endPulseAction
 
         # SET THE EVENT TO TRIGGER THE SMU'S TO THE ARM LAYER
         # A typical measurement goes from idle -> arm -> trigger.
         # The 'trigger.event_id' option sets the transition arm -> trigger
         # to occur after sending *trg to the instrument.
 
-        smu_sweep.trigger.arm.stimulus = self.trigger.EVENT_ID
+        smu1.trigger.arm.stimulus = self.trigger.EVENT_ID
 
         # Prepare an event blender (blender #1) that triggers when
         # the smua enters the trigger layer or reaches the end of a
@@ -645,37 +621,35 @@ class Keithley2600(Keithley2600Base):
 
         # triggers when either of the stimuli are true ('or enable')
         self.trigger.blender[1].orenable = True
-        self.trigger.blender[1].stimulus[1] = smu_sweep.trigger.ARMED_EVENT_ID
-        self.trigger.blender[1].stimulus[2] = smu_sweep.trigger.PULSE_COMPLETE_EVENT_ID
+        self.trigger.blender[1].stimulus[1] = smu1.trigger.ARMED_EVENT_ID
+        self.trigger.blender[1].stimulus[2] = smu1.trigger.PULSE_COMPLETE_EVENT_ID
 
-        # SET THE smu_sweep SOURCE STIMULUS TO BE EVENT BLENDER #1
+        # SET THE smu1 SOURCE STIMULUS TO BE EVENT BLENDER #1
         # A source measure cycle within the trigger layer will occur when
         # either the trigger layer is entered (termed 'armed event') for the
         # first time or a single cycle of the trigger layer is complete (termed
         # 'pulse complete event').
 
-        smu_sweep.trigger.source.stimulus = self.trigger.blender[1].EVENT_ID
+        smu1.trigger.source.stimulus = self.trigger.blender[1].EVENT_ID
 
         # PREPARE AN EVENT BLENDER (blender #2) THAT TRIGGERS WHEN BOTH SMU'S
         # HAVE COMPLETED A MEASUREMENT.
         # This is needed to prevent the next source measure cycle from occuring
         # before the measurement on both channels is complete.
 
-        self.trigger.blender[2].orenable = False  # triggers when both stimuli are true
-        self.trigger.blender[2].stimulus[1] = smu_sweep.trigger.MEASURE_COMPLETE_EVENT_ID
-        self.trigger.blender[2].stimulus[2] = smu_fix.trigger.MEASURE_COMPLETE_EVENT_ID
+        self.trigger.blender[2].orenable = True  # triggers when both stimuli are true
+        self.trigger.blender[2].stimulus[1] = smu1.trigger.MEASURE_COMPLETE_EVENT_ID
 
-        # SET THE smu_sweep ENDPULSE STIMULUS TO BE EVENT BLENDER #2
-        smu_sweep.trigger.endpulse.stimulus = self.trigger.blender[2].EVENT_ID
+        # SET THE smu1 ENDPULSE STIMULUS TO BE EVENT BLENDER #2
+        smu1.trigger.endpulse.stimulus = self.trigger.blender[2].EVENT_ID
 
-        # TURN ON smu_sweep AND smu_fix
-        smu_sweep.source.output = smu_sweep.OUTPUT_ON
-        smu_fix.source.output = smu_fix.OUTPUT_ON
+        # TURN ON smu1 AND smu2
+        smu1.source.output = smu1.OUTPUT_ON
 
         # INITIATE MEASUREMENT
         # prepare SMUs to wait for trigger
-        smu_sweep.trigger.initiate()
-        smu_fix.trigger.initiate()
+        smu1.trigger.initiate()
+
         # send trigger
         self._write('*trg')
 
@@ -695,15 +669,219 @@ class Keithley2600(Keithley2600Base):
 
         # EXTRACT DATA FROM SMU BUFFERS
 
-        Vsweep = self.readBuffer(buffer_sweep_2)
-        Isweep = self.readBuffer(buffer_sweep_1)
-        Vfix = self.readBuffer(buffer_fix_2)
-        Ifix = self.readBuffer(buffer_fix_1)
+        v_smu1 = self.readBuffer(buffer_smu1_2)
+        i_smu1 = self.readBuffer(buffer_smu1_1)
 
-        self.clearBuffers()
+        self.clearBuffer(smu1)
+
         self.busy = False
 
-        return Vsweep, Isweep, Vfix, Ifix
+        return v_smu1, i_smu1
+
+    def voltageSweepDualSMU(self, smu1, smu2, smu1_sweeplist, smu2_sweeplist, tInt, delay, pulsed):
+        """
+        Sweeps voltages at two SMUs. Measures and returns current and voltage during sweep.
+
+        INPUTS:
+            smu1 - 1st SMU to be sweept
+            smu2 - 2nd SMU to be sweept
+            smu1_sweeplist - array of voltages to sweep
+            smu2_sweeplist - array of voltages to sweep
+            tInt - integration time per data point (float)
+            delay - settling delay before measurement (float)
+            pulsed - continous or pulsed sweep (bool)
+        """
+
+        # input checks
+        self._check_smu(smu1)
+        self._check_smu(smu2)
+
+        assert len(smu1_sweeplist) == len(smu2_sweeplist)
+
+        # set state to busy
+        self.busy = True
+        # Define lists containing results. If we abort early, we have something to return.
+        v_smu1, i_smu1, v_smu2, i_smu2 = [], [], [], []
+
+        if self.abort_event.is_set():
+            self.busy = False
+            return v_smu1, i_smu1, v_smu2, i_smu2
+
+        # Setup smua/smub for sweep measurement. The voltage is swept through the given lists
+
+        # setup smu1 and smu2 to sweep through lists on trigger
+        smu1.trigger.source.listv(smu1_sweeplist)
+        smu1.trigger.source.action = smu1.ENABLE
+
+        smu2.trigger.source.listv(smu2_sweeplist)
+        smu2.trigger.source.action = smu2.ENABLE
+
+        # CONFIGURE INTEGRATION TIME FOR EACH MEASUREMENT
+        nplc = tInt * self.localnode.linefreq
+        smu1.measure.nplc = nplc
+        smu2.measure.nplc = nplc
+
+        # CONFIGURE SETTLING TIME FOR GATE VOLTAGE, I-LIMIT, ETC...
+        smu1.measure.delay = delay
+        smu2.measure.delay = delay
+
+        smu1.measure.autorangei = smu1.AUTORANGE_ON
+        smu2.measure.autorangei = smu2.AUTORANGE_ON
+
+        # smu1.trigger.source.limiti = 0.1
+        # smu2.trigger.source.limiti = 0.1
+
+        smu1.source.func = smu1.OUTPUT_DCVOLTS
+        smu2.source.func = smu2.OUTPUT_DCVOLTS
+
+        # 2-wire measurement (use SENSE_REMOTE for 4-wire)
+        # smu1.sense = smu1.SENSE_LOCAL
+        # smu2.sense = smu2.SENSE_LOCAL
+
+        # clears SMU buffers
+        smu1.nvbuffer1.clear()
+        smu1.nvbuffer2.clear()
+        smu2.nvbuffer1.clear()
+        smu2.nvbuffer2.clear()
+
+        smu1.nvbuffer1.clearcache()
+        smu1.nvbuffer2.clearcache()
+        smu2.nvbuffer1.clearcache()
+        smu2.nvbuffer2.clearcache()
+
+        # diplay current values during measurement
+        self.display.smua.measure.func = self.display.MEASURE_DCAMPS
+        self.display.smub.measure.func = self.display.MEASURE_DCAMPS
+
+        # SETUP TRIGGER ARM AND COUNTS
+        # trigger count = number of data points in measurement
+        # arm count = number of times the measurement is repeated (set to 1)
+
+        npts = len(smu1_sweeplist)
+
+        smu1.trigger.count = npts
+        smu2.trigger.count = npts
+
+        # SET THE MEASUREMENT TRIGGER ON BOTH SMU'S
+        # Set measurment to trigger once a change in the gate value on
+        # sweep smu is complete, i.e., a measurment will occur
+        # after the voltage is stepped.
+        # Both channels should be set to trigger on the sweep smu event
+        # so the measurements occur at the same time.
+
+        # enable smu
+        smu1.trigger.measure.action = smu1.ENABLE
+        smu2.trigger.measure.action = smu2.ENABLE
+
+        # measure current on trigger, store in buffer of smu
+        buffer_smu1_1 = '%s.nvbuffer1' % self._get_smu_string(smu1)
+        buffer_smu1_2 = '%s.nvbuffer2' % self._get_smu_string(smu1)
+
+        buffer_smu2_1 = '%s.nvbuffer1' % self._get_smu_string(smu2)
+        buffer_smu2_2 = '%s.nvbuffer2' % self._get_smu_string(smu2)
+
+        smu1.trigger.measure.iv(buffer_smu1_1, buffer_smu1_2)
+        smu2.trigger.measure.iv(buffer_smu2_1, buffer_smu2_2)
+
+        # initiate measure trigger when source is complete
+        smu1.trigger.measure.stimulus = smu1.trigger.SOURCE_COMPLETE_EVENT_ID
+        smu2.trigger.measure.stimulus = smu1.trigger.SOURCE_COMPLETE_EVENT_ID
+
+        # SET THE ENDPULSE ACTION TO HOLD
+        # Options are SOURCE_HOLD AND SOURCE_IDLE, hold maintains same voltage
+        # throughout step in sweep (typical IV sweep behavior). idle will allow
+        # pulsed IV sweeps.
+
+        if pulsed:
+            endPulseAction = 0  # SOURCE_IDLE
+        elif not pulsed:
+            endPulseAction = 1  # SOURCE_HOLD
+        else:
+            raise TypeError("'pulsed' must be of type 'bool'.")
+
+        smu1.trigger.endpulse.action = endPulseAction
+        smu2.trigger.endpulse.action = endPulseAction
+
+        # SET THE ENDSWEEP ACTION TO HOLD IF NOT PULSED
+        # Output voltage will be held after sweep is done!
+
+        smu1.trigger.endsweep.action = endPulseAction
+        smu2.trigger.endsweep.action = endPulseAction
+
+        # SET THE EVENT TO TRIGGER THE SMU'S TO THE ARM LAYER
+        # A typical measurement goes from idle -> arm -> trigger.
+        # The 'trigger.event_id' option sets the transition arm -> trigger
+        # to occur after sending *trg to the instrument.
+
+        smu1.trigger.arm.stimulus = self.trigger.EVENT_ID
+
+        # Prepare an event blender (blender #1) that triggers when
+        # the smua enters the trigger layer or reaches the end of a
+        # single trigger layer cycle.
+
+        # triggers when either of the stimuli are true ('or enable')
+        self.trigger.blender[1].orenable = True
+        self.trigger.blender[1].stimulus[1] = smu1.trigger.ARMED_EVENT_ID
+        self.trigger.blender[1].stimulus[2] = smu1.trigger.PULSE_COMPLETE_EVENT_ID
+
+        # SET THE smu1 SOURCE STIMULUS TO BE EVENT BLENDER #1
+        # A source measure cycle within the trigger layer will occur when
+        # either the trigger layer is entered (termed 'armed event') for the
+        # first time or a single cycle of the trigger layer is complete (termed
+        # 'pulse complete event').
+
+        smu1.trigger.source.stimulus = self.trigger.blender[1].EVENT_ID
+
+        # PREPARE AN EVENT BLENDER (blender #2) THAT TRIGGERS WHEN BOTH SMU'S
+        # HAVE COMPLETED A MEASUREMENT.
+        # This is needed to prevent the next source measure cycle from occuring
+        # before the measurement on both channels is complete.
+
+        self.trigger.blender[2].orenable = False  # triggers when both stimuli are true
+        self.trigger.blender[2].stimulus[1] = smu1.trigger.MEASURE_COMPLETE_EVENT_ID
+        self.trigger.blender[2].stimulus[2] = smu2.trigger.MEASURE_COMPLETE_EVENT_ID
+
+        # SET THE smu1 ENDPULSE STIMULUS TO BE EVENT BLENDER #2
+        smu1.trigger.endpulse.stimulus = self.trigger.blender[2].EVENT_ID
+
+        # TURN ON smu1 AND smu2
+        smu1.source.output = smu1.OUTPUT_ON
+        smu2.source.output = smu2.OUTPUT_ON
+
+        # INITIATE MEASUREMENT
+        # prepare SMUs to wait for trigger
+        smu1.trigger.initiate()
+        smu2.trigger.initiate()
+        # send trigger
+        self._write('*trg')
+
+        # CHECK STATUS BUFFER FOR MEASUREMENT TO FINISH
+        # Possible return values:
+        # 6 = smua and smub sweeping
+        # 4 = only smub sweeping
+        # 2 = only smua sweeping
+        # 0 = neither smu sweeping
+
+        status = 0
+        while status == 0:  # while loop that runs until the sweep begins
+            status = self.status.operation.sweeping.condition
+
+        while status > 0:  # while loop that runs until the sweep ends
+            status = self.status.operation.sweeping.condition
+
+        # EXTRACT DATA FROM SMU BUFFERS
+
+        v_smu1 = self.readBuffer(buffer_smu1_2)
+        i_smu1 = self.readBuffer(buffer_smu1_1)
+        v_smu2 = self.readBuffer(buffer_smu2_2)
+        i_smu2 = self.readBuffer(buffer_smu2_1)
+
+        self.clearBuffer(smu1)
+        self.clearBuffer(smu2)
+
+        self.busy = False
+
+        return v_smu1, i_smu1, v_smu2, i_smu2
 
 # =============================================================================
 # Define higher level control functions
@@ -718,6 +896,7 @@ class Keithley2600(Keithley2600Base):
         """
         self.busy = True
         self.abort_event.clear()
+
         msg = ('Recording transfer curve with Vg from %sV to %sV, Vd = %s V. '
                % (VgStart, VgStop, VdList))
         logger.info(msg)
@@ -725,33 +904,43 @@ class Keithley2600(Keithley2600Base):
         # create TransistorSweepData instance
         sd = TransistorSweepData(sweepType='transfer')
 
+        # create array with gate voltage steps, always inlude a last step at / beyond VgStop
+        step = np.sign(VgStop - VgStart) * abs(VgStep)
+        sweeplist_gate = np.arange(VgStart, VgStop + step, step)
+
+        # record forward and backward sweeps for every drain voltage step
         for Vdrain in VdList:
+
+            # check for abort event
             if self.abort_event.is_set():
                 self.reset()
                 self.beeper.beep(0.3, 2400)
                 return sd
 
-            # conduct forward and reverse sweeps
-            VsFWD, IsFWD, VfFWD, IfFWD = self.voltageSweep(smu_gate, smu_drain,
-                                                           VgStart, VgStop,
-                                                           -abs(VgStep),
-                                                           Vdrain, tInt, delay,
-                                                           pulsed)
+            # create array with drain voltages
+            if Vdrain == 'trailing':
+                sweeplist_drain = sweeplist_gate
+            else:
+                sweeplist_drain = np.full_like(sweeplist_gate, Vdrain)
+
+            # conduct forward sweep
+            vg_fwd, ig_fwd, vd_fwd, id_fwd = self.voltageSweepDualSMU(
+                    smu_gate, smu_drain, sweeplist_gate, sweeplist_drain, tInt, delay, pulsed
+                    )
 
             if not self.abort_event.is_set():
-                # add data to TransistorSweepData instance
-                # discard data if aborted by user
-                sd.append(vFix=Vdrain, vSweep=VsFWD, iDrain=IfFWD, iGate=IsFWD)
+                sd.append(vFix=Vdrain, vSweep=vg_fwd, iDrain=id_fwd, iGate=ig_fwd)
 
-            VsRVS, IsRVS, VfRVS, IfRVS = self.voltageSweep(smu_gate, smu_drain,
-                                                           VgStop, VgStart,
-                                                           abs(VgStep), Vdrain,
-                                                           tInt, delay, pulsed)
+            # conduct backward sweep
+            sweeplist_gate = np.flip(sweeplist_gate)
+            sweeplist_drain = np.flip(sweeplist_drain)
+
+            vg_rvs, ig_rvs, vd_rvs, id_rvs = self.voltageSweepDualSMU(
+                    smu_gate, smu_drain, sweeplist_gate, sweeplist_drain, tInt, delay, pulsed
+                    )
 
             if not self.abort_event.is_set():
-                # add data to TransistorSweepData instance
-                # discard data if aborted by user
-                sd.append(vFix=Vdrain, vSweep=VsRVS, iDrain=IfRVS, iGate=IsRVS)
+                sd.append(vFix=Vdrain, vSweep=vg_rvs, iDrain=id_rvs, iGate=ig_rvs)
 
         self.reset()
         self.beeper.beep(0.3, 2400)
@@ -774,31 +963,36 @@ class Keithley2600(Keithley2600Base):
         # create TransistorSweepData instance
         sd = TransistorSweepData(sweepType='output')
 
+        # create array with drain voltage steps, always inlude a last step at / beyond VgStop
+        step = np.sign(VdStop - VdStart) * abs(VdStep)
+        sweeplist_drain = np.arange(VdStart, VdStop + step, step)
+
         for Vgate in VgList:
             if self.abort_event.is_set():
                 self.reset()
                 self.beeper.beep(0.3, 2400)
                 return sd
 
-            # conduct forward and reverse sweeps
-            VsFWD, IsFWD, VfFWD, IfFWD = self.voltageSweep(smu_drain, smu_gate,
-                                                           VdStart, VdStop,
-                                                           -abs(VdStep), Vgate,
-                                                           tInt, delay, pulsed)
-            if not self.abort_event.is_set():
-                # add data to TransistorSweepData instance
-                # discard data if aborted by user
-                sd.append(vFix=Vgate, vSweep=VsFWD, iDrain=IsFWD, iGate=IfFWD)
+            # create array with gate voltages
+            sweeplist_gate = np.full_like(sweeplist_drain, Vgate)
 
-            VsRVS, IsRVS, VfRVS, IfRVS = self.voltageSweep(smu_drain, smu_gate,
-                                                           VdStop, VdStart,
-                                                           abs(VdStep), Vgate,
-                                                           tInt, delay, pulsed)
+            # conduct forward sweep
+            vd_fwd, id_fwd, vg_fwd, ig_fwd = self.voltageSweepDualSMU(
+                    smu_drain, smu_gate, sweeplist_drain, sweeplist_gate, tInt, delay, pulsed
+                    )
+            if not self.abort_event.is_set():
+                sd.append(vFix=Vgate, vSweep=vd_fwd, iDrain=id_fwd, iGate=ig_fwd)
+
+            # conduct backward sweep
+            sweeplist_gate = np.flip(sweeplist_gate)
+            sweeplist_drain = np.flip(sweeplist_drain)
+
+            vd_rvs, id_rvs, vg_rvs, ig_rvs = self.voltageSweepDualSMU(
+                    smu_drain, smu_gate, sweeplist_drain, sweeplist_gate, tInt, delay, pulsed
+                    )
 
             if not self.abort_event.is_set():
-                # add data to TransistorSweepData instance
-                # discard data if aborted by user
-                sd.append(vFix=Vgate, vSweep=VsRVS, iDrain=IsRVS, iGate=IfRVS)
+                sd.append(vFix=Vgate, vSweep=vd_rvs, iDrain=id_rvs, iGate=ig_rvs)
 
         self.reset()
         self.beeper.beep(0.3, 2400)


### PR DESCRIPTION
 - The _voltageSweep_ method has been split to _voltageSweepSingleSMU_ and _voltageSweepDualSMU_.
- Sweep methods now require a list, tuple, or NumPy array of voltage steps as input instead of start, stop, and step parameters. This allows for custom, non-linear sweeps.