### PR TITLE
Small addition to allow context managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ pip install git+https://github.com/OE-FET/keithley2600
 ## Usage
 
 Connect to the Keithley 2600 and perform some base commands:
+
 ```python
 from keithley2600 import Keithley2600
 
@@ -64,6 +65,25 @@ i = k.smua.measure.i()  # measures current at smuA
 
 k.smua.measure.v(k.smua.nvbuffer1)  # measures the voltage, stores the result in buffer
 k.smua.nvbuffer1.clear()  # clears nvbuffer1 of SMUA
+```
+
+Alternatively, the device can be used in a context:
+
+```python
+from keithley2600 import Keithley2600
+
+with Keithley2600('TCPIP0::192.168.2.121::INSTR') as kth:
+    kth.reset()
+    smu = kth.smua
+    smu.sense = smu.SENSE_REMOTE
+    smu.source.limiti = 0.01  # mA
+    smu.source.autorangev = smu.AUTORANGE_ON
+    smu.source.func = smu.OUTPUT_DCVOLTS
+    smu.measure.autozero = smu.AUTOZERO_AUTO
+    smu.measure.autorangei = smu.AUTORANGE_ON
+    smu.measure.nplc = 16
+    smu.source.levelv = 3.3
+    smu.source.output = smu.OUTPUT_ON
 ```
 Higher level commands defined in the driver:
 

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -570,6 +570,14 @@ class Keithley2600Base(KeithleyClass):
         return f"<{self.__class__.__name__}({self.visa_address})>"
         
     def __enter__(self):
+        """
+        Allows usage in contexts ("with Keithley2600() as kth:")
+
+        - cleaning the error-queue helps with faulty scripts that leave the SMU in a
+          weird state
+        - restarting the script often fails at basic tasks (like accessing keithley.smua)
+          because the TSP-Command-Set wasn't read successfully (or other weird behavior).
+        """
         self.connection.write("errorqueue.clear()")
         return self
 

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -568,6 +568,13 @@ class Keithley2600Base(KeithleyClass):
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}({self.visa_address})>"
+        
+    def __enter__(self):
+        self.connection.write("errorqueue.clear()")
+        return self
+
+    def __exit__(self, *args):
+        self.disconnect()
 
     # =============================================================================
     # Connect to keithley


### PR DESCRIPTION
main problem I had: faulty scripts leave the SMU in a weird state - so restarting the script often fails at basic tasks (like accessing keithley.smua) because the TSP-Commant-Set wasn't read successfully (or other weird behavior). 

i added the option to use this module in a context and  haven't had the problem since. This way of accessing remote devices allows to automatically disconnect on exceptions.

```
with Keithley2600(f"TCPIP0::{smu_ip}::INSTR") as kth:
    kth.reset()
    smu = kth.smua
    smu.sense = smu.SENSE_REMOTE
    smu.source.limiti = current_A
    smu.source.autorangev = smu.AUTORANGE_ON
    smu.source.func = smu.OUTPUT_DCVOLTS
    smu.measure.autozero = smu.AUTOZERO_AUTO
    smu.measure.autorangei = smu.AUTORANGE_ON
    smu.measure.nplc = 16
    smu.source.levelv = voltage_V
    smu.source.output = smu.OUTPUT_ON
```