### PR TITLE
Replace np.complex (deprecated) with complex

### DIFF
--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -763,7 +763,7 @@ class Keithley2600Base(KeithleyClass):
             # convert some iterables to a TSP type list '{1,2,3,4}'
             return "{" + ", ".join([str(v) for v in value]) + "}"
         elif isinstance(value, (int, float, np.number)) and not isinstance(
-            value, np.complex
+            value, complex
         ):
             return str(value)
         else:

--- a/keithley2600/keithley_driver.py
+++ b/keithley2600/keithley_driver.py
@@ -762,9 +762,7 @@ class Keithley2600Base(KeithleyClass):
         elif hasattr(value, "__iter__"):
             # convert some iterables to a TSP type list '{1,2,3,4}'
             return "{" + ", ".join([str(v) for v in value]) + "}"
-        elif isinstance(value, (int, float, np.number)) and not isinstance(
-            value, complex
-        ):
+        elif isinstance(value, (int, float, np.number)):
             return str(value)
         else:
             raise ValueError(


### PR DESCRIPTION
`np.complex` was [deprecated in numpy 1.20.0](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and causes an error. It can be replaced with the builtin `complex` type of python. Since `np.complex` was only an alias for the builtin `complex`, this shouldn't change any behaviour.